### PR TITLE
Adjusted scripts to use python 2 or python 3

### DIFF
--- a/check_jedox_backup.py
+++ b/check_jedox_backup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 

--- a/check_jedox_ports.py
+++ b/check_jedox_ports.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 

--- a/check_jedox_services.py
+++ b/check_jedox_services.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # required : apt-get install python-psutil
 


### PR DESCRIPTION
This is needed on Debian 7 Wheezy because no psutil package is available compatible with python3
